### PR TITLE
chore: add gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+dist/
+api/
+node_modules/
+uploads/


### PR DESCRIPTION
## Summary
- ignore generated folders like `dist`, `api`, `node_modules`, and `uploads`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2ba80a5c0832b98854d428a79b8b8