### PR TITLE
Fail upload_photo auth when API key missing

### DIFF
--- a/api/upload_photo.php
+++ b/api/upload_photo.php
@@ -14,7 +14,7 @@ header('Content-Type: application/json; charset=utf-8');
 try {
   $clientKey = client_api_key();
   global $API_KEY;
-  if (isset($API_KEY) && $API_KEY && $clientKey && !hash_equals($API_KEY, $clientKey)) {
+  if (isset($API_KEY) && $API_KEY && (!$clientKey || !hash_equals($API_KEY, $clientKey))) {
     http_response_code(401);
     echo json_encode(['ok' => false, 'error' => 'unauthorized']); exit;
   }

--- a/tests/upload_photo_no_key.sh
+++ b/tests/upload_photo_no_key.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+# Send request to upload_photo without API key; expect unauthorized response.
+out=$(REQUEST_METHOD=POST API_KEY=test php api/upload_photo.php 2>&1 || true)
+echo "$out"
+# Ensure response indicates unauthorized
+if echo "$out" | grep -q 'unauthorized'; then
+  exit 0
+else
+  echo "Expected unauthorized response" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Require API key for `upload_photo.php` requests and use `hash_equals` for timing-safe comparison
- Add test script that confirms missing API key is rejected

## Testing
- `tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2de257bd8832b8ff0c2fd0b30c5f3