### PR TITLE
Use constant-time API key check

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -51,6 +51,17 @@ function client_api_key() {
   return $key;
 }
 
+function require_api_key() {
+  global $API_KEY;
+  $key = client_api_key();
+  if (!$key || !hash_equals($API_KEY, $key)) {
+    http_response_code(401);
+    echo json_encode(['ok' => false, 'error' => 'unauthorized'], JSON_UNESCAPED_SLASHES);
+    exit;
+  }
+  return $key;
+}
+
 function cors_preflight() {
   global $CORS_ALLOWED_ORIGINS;
   $origin = $_SERVER['HTTP_ORIGIN'] ?? '';

--- a/api/event_teams.php
+++ b/api/event_teams.php
@@ -5,11 +5,7 @@ cors_preflight();
 header('Content-Type: application/json; charset=utf-8');
 
 try {
-  $key = client_api_key();
-  if (!$key || $key !== $API_KEY) {
-    http_response_code(401);
-    echo json_encode(['ok' => false, 'error' => 'unauthorized']); exit;
-  }
+  require_api_key();
 
   $event = isset($_GET['event']) ? trim($_GET['event']) : '';
   if ($event === '') {

--- a/api/schedule.php
+++ b/api/schedule.php
@@ -5,11 +5,7 @@ cors_preflight();
 header('Content-Type: application/json; charset=utf-8');
 
 try {
-  $key = client_api_key();
-  if (!$key || $key !== $API_KEY) {
-    http_response_code(401);
-    echo json_encode(['ok' => false, 'error' => 'unauthorized']); exit;
-  }
+  require_api_key();
 
   $event = isset($_GET['event']) ? trim($_GET['event']) : '';
   if ($event === '') {

--- a/api/sync.php
+++ b/api/sync.php
@@ -9,12 +9,7 @@ require_once __DIR__ . '/config.php';
 cors_preflight();
 
 // Verify API key
-$key = client_api_key();
-if (!$key || $key !== $API_KEY) {
-  http_response_code(401);
-  echo json_encode(['ok' => false, 'error' => 'unauthorized'], JSON_UNESCAPED_SLASHES);
-  exit;
-}
+require_api_key();
 
 // Decode JSON body
 $raw = file_get_contents('php://input');

--- a/api/team_detail.php
+++ b/api/team_detail.php
@@ -5,11 +5,7 @@ cors_preflight();
 header('Content-Type: application/json; charset=utf-8');
 
 try {
-  $key = client_api_key();
-  if (!$key || $key !== $API_KEY) {
-    http_response_code(401);
-    echo json_encode(['ok' => false, 'error' => 'unauthorized']); exit;
-  }
+  require_api_key();
 
   $event = isset($_GET['event']) ? trim($_GET['event']) : '';
   $team  = isset($_GET['team'])  ? intval($_GET['team']) : 0;


### PR DESCRIPTION
## Summary
- Add `require_api_key()` helper with constant-time `hash_equals` comparison
- Replace duplicated API key checks in endpoints with `require_api_key`

## Testing
- `php -l api/config.php`
- `php -l api/schedule.php`
- `php -l api/sync.php`
- `php -l api/event_teams.php`
- `php -l api/team_detail.php`
- `./tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2fa792530832b843bdc694cc36775