### PR TITLE
chore: ignore node_modules at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # Build artifacts
 dist/
 scout/dist/
-node_modules/
-scout/node_modules
+**/node_modules/
 uploads/
 
 # Local environment configuration


### PR DESCRIPTION
## Summary
- ignore `node_modules` directories anywhere in the tree with `**/node_modules/`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `git ls-files | grep node_modules`

------
https://chatgpt.com/codex/tasks/task_e_68c2fb9dc348832b9a4295a964bce7ca