### PR TITLE
Remove API key from client configuration endpoint

### DIFF
--- a/api/client-config.php
+++ b/api/client-config.php
@@ -6,6 +6,5 @@ header('Content-Type: application/json');
 
 echo json_encode([
   'syncUrl' => $SYNC_URL ?? '',
-  'apiKey'  => $API_KEY ?? '',
 ]);
 ?>

--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -17,18 +17,18 @@ export default function App() {
   const [envDefaults, setEnvDefaults] = React.useState({
     eventKey: import.meta.env.VITE_EVENT_KEY || '',
     syncUrl: '',
-    apiKey: ''
+    apiKey: import.meta.env.VITE_API_KEY || ''
   })
 
   // Load saved settings once — and force-merge env defaults into blanks
   React.useEffect(() => {
     (async () => {
-      let defaults = { eventKey: import.meta.env.VITE_EVENT_KEY || '', syncUrl: '', apiKey: '' }
+      let defaults = { eventKey: import.meta.env.VITE_EVENT_KEY || '', syncUrl: '', apiKey: import.meta.env.VITE_API_KEY || '' }
       try {
         const res = await fetch('/api/client-config.php')
         if (res.ok) {
           const cfg = await res.json()
-          defaults = { ...defaults, syncUrl: cfg.syncUrl || '', apiKey: cfg.apiKey || '' }
+          defaults = { ...defaults, syncUrl: cfg.syncUrl || '' }
         }
       } catch {}
 

--- a/scout/src/settings.ts
+++ b/scout/src/settings.ts
@@ -53,7 +53,7 @@ function ensureDeviceId(existing?: string): string {
 export function normalizeSettings(current: Partial<Settings>): Settings {
   // Read envs (may be empty in some deployments)
   const envSync = ''
-  const envKey  = ''
+  const envKey  = (import.meta.env && (import.meta.env as any).VITE_API_KEY) || ''
   const envEvt  = (import.meta.env && (import.meta.env as any).VITE_EVENT_KEY) || ''
 
   // Pick values in priority: current → env → fallback


### PR DESCRIPTION
## Summary
- Stop exposing API key via `api/client-config.php`
- Load API key from `VITE_API_KEY` environment variable on the client instead of unauthenticated endpoint

## Testing
- `php -l api/client-config.php`
- `npm run build`
- `bash tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc42a750832b894586a99062a966