### PR TITLE
Sanitize event param and validate upload path

### DIFF
--- a/api/upload_photo.php
+++ b/api/upload_photo.php
@@ -20,7 +20,8 @@ try {
   }
 
   // ---- Params ----
-  $event = isset($_GET['event']) ? strtolower(trim($_GET['event'])) : '';
+  $event = isset($_GET['event']) ? trim($_GET['event']) : '';
+  $event = preg_replace('~[^a-z0-9_]~', '', strtolower($event));
   $team  = isset($_GET['team'])  ? intval($_GET['team']) : 0;
   $nameQ = isset($_GET['name'])  ? trim($_GET['name']) : '';
 
@@ -64,7 +65,12 @@ try {
     }
   }
 
-  $targetPath = $targetDir . '/' . $safe;
+  $realTargetDir = realpath($targetDir);
+  if ($realTargetDir === false || strpos($realTargetDir, $UPLOADS_DIR) !== 0) {
+    throw new Exception('invalid_target_dir');
+  }
+
+  $targetPath = $realTargetDir . '/' . $safe;
 
   // ---- Read body/file ----
   $content = null;


### PR DESCRIPTION
## Summary
- Sanitize the `event` query parameter to lowercase alphanumerics and underscores
- Ensure the resolved upload directory remains inside the canonical `uploads` path

## Testing
- `php -l api/upload_photo.php`
- `bash tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2ff1de33c832b83fcda460a61f891