### PR TITLE
Use require_api_key in photo upload endpoint

### DIFF
--- a/api/upload_photo.php
+++ b/api/upload_photo.php
@@ -12,12 +12,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 // --- Auth ---
 try {
-  $clientKey = client_api_key();
-  global $API_KEY;
-  if (isset($API_KEY) && $API_KEY && (!$clientKey || !hash_equals($API_KEY, $clientKey))) {
-    http_response_code(401);
-    echo json_encode(['ok' => false, 'error' => 'unauthorized']); exit;
-  }
+  require_api_key();
 
   // ---- Params ----
   $event = isset($_GET['event']) ? strtolower(trim($_GET['event'])) : '';


### PR DESCRIPTION
## Summary
- Refactor upload_photo to rely on require_api_key for authentication

## Testing
- `php -l api/upload_photo.php`
- `bash tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2ff190a60832ba8798bb29406e4af