### PR TITLE
Include toggle metrics on dashboard and streamline team modal

### DIFF
--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -40,7 +40,12 @@ try {
 
     $m = json_decode($r['metrics_json'] ?? "{}", true);
     if (is_array($m)) {
-      foreach ($m as $k=>$v) { if (!is_numeric($v)) continue;
+      foreach ($m as $k=>$v) {
+        // Allow boolean metrics (toggles) by treating true/false as 1/0
+        if (is_bool($v)) {
+          $v = $v ? 1 : 0;
+        }
+        if (!is_numeric($v)) continue;
         if (!isset($teamsAgg[$tnum]['metrics_sum'][$k])) $teamsAgg[$tnum]['metrics_sum'][$k] = 0;
         $teamsAgg[$tnum]['metrics_sum'][$k] += (float)$v;
         $metricsKeys[$k] = true;


### PR DESCRIPTION
## Summary
- count boolean match metrics so dashboard can toggle averages like auto mobility and coop
- simplify team modal to show recent matches and link to Statbotics
- include coop metric in Endgame preset filters

## Testing
- `php -l api/dash_summary.php`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c309365b44832b8d610eef1edff9a8