### PR TITLE
fix: expose defense averages

### DIFF
--- a/api/team_detail.php
+++ b/api/team_detail.php
@@ -70,9 +70,9 @@ try {
       COUNT(*)                           AS played,
       AVG(NULLIF(penalties, NULL))       AS penalties_avg,
       AVG(NULLIF(driver_skill, NULL))    AS driver_skill_avg,
-      AVG(COALESCE(broke_down, 0))       AS broke_down_avg,
-      AVG(COALESCE(defended_by, 0))      AS defended_by_avg,
-      AVG(COALESCE(defense_played, 0))   AS defense_played_avg
+      AVG(broke_down)                    AS broke_down_avg,
+      AVG(defended_by)                   AS defended_by_avg,
+      AVG(defense_played)                AS defense_played_avg
     FROM match_records
     WHERE team_number = ?
       AND match_key LIKE CONCAT(?, '_%')
@@ -154,11 +154,11 @@ try {
     'pit' => $pit,
     'recent' => $recent,
     'played' => intval($agg['played'] ?? 0),
-    'penalties_avg' => $agg['penalties_avg'] !== null ? floatval($agg['penalties_avg']) : null,
-    'driver_skill_avg' => $agg['driver_skill_avg'] !== null ? floatval($agg['driver_skill_avg']) : null,
-    'broke_down_avg' => floatval($agg['broke_down_avg'] ?? 0),
-    'defended_by_avg' => floatval($agg['defended_by_avg'] ?? 0),
-    'defense_played_avg' => floatval($agg['defense_played_avg'] ?? 0),
+    'penalties_avg' => $agg['penalties_avg'] !== null ? round(floatval($agg['penalties_avg']), 2) : null,
+    'driver_skill_avg' => $agg['driver_skill_avg'] !== null ? round(floatval($agg['driver_skill_avg']), 2) : null,
+    'broke_down_avg' => $agg['broke_down_avg'] !== null ? round(floatval($agg['broke_down_avg']), 2) : null,
+    'defended_by_avg' => $agg['defended_by_avg'] !== null ? round(floatval($agg['defended_by_avg']), 2) : null,
+    'defense_played_avg' => $agg['defense_played_avg'] !== null ? round(floatval($agg['defense_played_avg']), 2) : null,
     'cards' => $cards,
     'flags_pct' => (object)$flagsPct,
     'endgame_pct' => (object)$endgamePct

--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -349,6 +349,10 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
     return posStr || '-'
   }
 
+  function fmt(v?: number | null) {
+    return v !== null && v !== undefined ? v.toFixed(2) : '-'
+  }
+
   const pit = detail?.pit || null
   const dims = parseJsonMaybe(pit?.dims_json)
   const mechs = parseJsonMaybe(pit?.mechanisms_json)
@@ -388,7 +392,7 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
                 ))}
               </ul>
               <p className="help">
-                Played: {detail?.played ?? 0} · Penalties Avg: {detail?.penalties_avg ?? '-'} · Driver Avg: {detail?.driver_skill_avg ?? '-'} · Broke Down Avg: {detail?.broke_down_avg ?? '-'} · Defended By Avg: {detail?.defended_by_avg ?? '-'} · Defense Played Avg: {detail?.defense_played_avg ?? '-'}
+                Played: {detail?.played ?? 0} · Penalties Avg: {fmt(detail?.penalties_avg)} · Driver Avg: {fmt(detail?.driver_skill_avg)} · Broke Down Avg: {fmt(detail?.broke_down_avg)} · Defended By Avg: {fmt(detail?.defended_by_avg)} · Defense Played Avg: {fmt(detail?.defense_played_avg)}
               </p>
               {detail?.cards && detail.cards.length > 0 && (
                 <p className="help">Cards: {detail.cards.join(', ')}</p>


### PR DESCRIPTION
## Summary
- compute defense and breakdown averages in team details, ignoring nulls and rounding for display
- format team modal averages with fixed decimals

## Testing
- `php -l api/team_detail.php`
- `npm --prefix scout test` *(fails: Missing script "test")*
- `npm --prefix scout run build`


------
https://chatgpt.com/codex/tasks/task_e_68c31e3207f0832b94fa7083dd187707