### PR TITLE
Handle modern endgame key in dashboard summary

### DIFF
--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -123,7 +123,7 @@ try {
         $select_pct[$k][$val] = round(100.0*$cnt/$played,1);
       }
     }
-    $end_pct = $select_pct['endgame'] ?? $select_pct['endgame_climb'] ?? [];
+    $end_pct = $select_pct['endgame'] ?? $select_pct['endgame_climb'] ?? $select_pct['endgame_status'] ?? [];
     $card_pct = []; foreach ($agg['card'] as $k=>$cnt) { $card_pct[$k] = round(100.0*$cnt/$played,1); }
 
     $teams[] = [


### PR DESCRIPTION
## Summary
- Update endgame percentage logic to look for `endgame_status`

## Testing
- `php -l api/dash_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_68c33d8e6450832bbc88990e84bf8508