### PR TITLE
Unify endgame field for recent game configs

### DIFF
--- a/scout/src/games/2024.crescendo.ts
+++ b/scout/src/games/2024.crescendo.ts
@@ -27,12 +27,12 @@ export const GAME_2024: GameConfig = {
       fields: [
         {
           kind: 'select',
-          key: 'endgame_status',
+          key: 'endgame',
           label: 'Endgame',
           options: [
-            { value: 'none',  label: 'None' },
-            { value: 'park',  label: 'Park' },
-            { value: 'onstage', label: 'Onstage' },
+            { value: 'none',      label: 'None' },
+            { value: 'park',      label: 'Park' },
+            { value: 'onstage',   label: 'Onstage' },
             { value: 'harmonize', label: 'Harmonize' }
           ]
         },

--- a/scout/src/games/2025.reefscape.ts
+++ b/scout/src/games/2025.reefscape.ts
@@ -1,7 +1,7 @@
 import { GameConfig } from './types'
 
 // Reefscape (2025): per-level coral in Auto & Teleop + algae + mobility + coop + notes.
-// Endgame (climb) remains defined here so MatchForm won't duplicate it.
+// Endgame remains defined here so MatchForm won't duplicate it.
 export const GAME_2025: GameConfig = {
   id: 'reefscape-2025',
   name: 'Reefscape (2025)',
@@ -34,12 +34,12 @@ export const GAME_2025: GameConfig = {
       fields: [
         {
           kind: 'select',
-          key: 'endgame_climb',
+          key: 'endgame',
           label: 'Endgame',
           options: [
-            { value: 'none',   label: 'None' },
-            { value: 'low',    label: 'Shallow' },
-            { value: 'mid',    label: 'Deep' }
+            { value: 'none',    label: 'None' },
+            { value: 'shallow', label: 'Shallow' },
+            { value: 'deep',    label: 'Deep' }
           ]
         },
         { kind: 'toggle', key: 'coop', label: 'Coopertition Achieved' }


### PR DESCRIPTION
## Summary
- Replace `endgame_climb` with `endgame` in 2025 Reefscape config and rename options to none/shallow/deep
- Rename 2024 Crescendo config `endgame_status` to `endgame`
- Build front-end so Dashboard metrics include the updated endgame options

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3433af494832b96a0366273d53d41