### PR TITLE
Use unified endgame key in dashboard summary

### DIFF
--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -123,7 +123,11 @@ try {
         $select_pct[$k][$val] = round(100.0*$cnt/$played,1);
       }
     }
-    $end_pct = $select_pct['endgame'] ?? $select_pct['endgame_climb'] ?? $select_pct['endgame_status'] ?? [];
+    if (isset($select_pct['endgame'])) {
+      $end_pct = $select_pct['endgame'];
+    } else {
+      $end_pct = $select_pct['endgame_climb'] ?? $select_pct['endgame_status'] ?? [];
+    }
     $card_pct = []; foreach ($agg['card'] as $k=>$cnt) { $card_pct[$k] = round(100.0*$cnt/$played,1); }
 
     $teams[] = [


### PR DESCRIPTION
## Summary
- Ensure dash summary prefers new `endgame` field and only falls back to legacy endgame keys

## Testing
- `php -l api/dash_summary.php`
- `tests/upload_photo_no_key.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c34445249c832b899b7118f2b6ae67