### PR TITLE
Normalize endgame select columns

### DIFF
--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -123,11 +123,12 @@ try {
         $select_pct[$k][$val] = round(100.0*$cnt/$played,1);
       }
     }
-    if (isset($select_pct['endgame'])) {
-      $end_pct = $select_pct['endgame'];
-    } else {
-      $end_pct = $select_pct['endgame_climb'] ?? $select_pct['endgame_status'] ?? [];
-    }
+    $select_pct['endgame'] = $select_pct['endgame']
+      ?? $select_pct['endgame_climb']
+      ?? $select_pct['endgame_status']
+      ?? [];
+    unset($select_pct['endgame_climb'], $select_pct['endgame_status']);
+    $end_pct = $select_pct['endgame'];
     $card_pct = []; foreach ($agg['card'] as $k=>$cnt) { $card_pct[$k] = round(100.0*$cnt/$played,1); }
 
     $teams[] = [


### PR DESCRIPTION
## Summary
- Ensure endgame percentage fallback covers legacy column names
- Remove legacy keys after unifying endgame percentages

## Testing
- `php -l api/dash_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_68c365b68988832bb3dfeee7457436c0