### PR TITLE
Fix endgame percentage display

### DIFF
--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -389,7 +389,7 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
               {detail?.endgame_pct && (
                 <ul>
                   {Object.entries(detail.endgame_pct as Record<string, number>).map(([k, v]: [string, number]) => (
-                    <li key={k} className="help">{`${k}: ${(v * 100).toFixed(0)}%`}</li>
+                    <li key={k} className="help">{`${k}: ${v.toFixed(1)}%`}</li>
                   ))}
                 </ul>
               )}


### PR DESCRIPTION
## Summary
- fix endgame percentage rendering to remove extra multiplier and display with one decimal

## Testing
- `npm run build`
- `node -e 'console.log(`${"deep"}: ${(40).toFixed(1)}%`);'`

------
https://chatgpt.com/codex/tasks/task_e_68c36c5eb144832b99f215dcd03551ee