### PR TITLE
Handle endgame aggregation case-insensitively

### DIFF
--- a/api/team_detail.php
+++ b/api/team_detail.php
@@ -121,8 +121,8 @@ try {
       // endgame
       $eg = $obj['endgame'] ?? $obj['endgame_climb'] ?? $obj['endgame_status'] ?? null;
       if ($eg !== null && $eg !== '') {
-        $k = trim((string)$eg);
-        $endgamePct[$k] = ($endgamePct[$k] ?? 0) + 1;
+        $eg = strtolower(trim((string)$eg));
+        $endgamePct[$eg] = ($endgamePct[$eg] ?? 0) + 1;
       }
 
       // flags


### PR DESCRIPTION
## Summary
- Normalize endgame values to lowercase before counting endgame percentages

## Testing
- `php -l api/team_detail.php`
- `php /tmp/test_endgame.php`

------
https://chatgpt.com/codex/tasks/task_e_68c36d1bf8bc832bb39ab6cf6c9875e6