### PR TITLE
Normalize event parameter for case-insensitive team detail queries

### DIFF
--- a/api/team_detail.php
+++ b/api/team_detail.php
@@ -7,7 +7,7 @@ header('Content-Type: application/json; charset=utf-8');
 try {
   require_api_key();
 
-  $event = isset($_GET['event']) ? trim($_GET['event']) : '';
+  $event = strtolower(trim($_GET['event'] ?? ''));
   $team  = isset($_GET['team'])  ? intval($_GET['team']) : 0;
 
   if ($event === '' || $team <= 0) {


### PR DESCRIPTION
## Summary
- Normalize `event` query parameter to lowercase in `team_detail.php`
- Ensure all match record queries use the normalized event for `LIKE` prefix matching

## Testing
- `php -l api/team_detail.php`


------
https://chatgpt.com/codex/tasks/task_e_68c370852178832baaaf73fb1a8d80aa