### PR TITLE
fix: keep team modal open after closing photo lightbox

### DIFF
--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -405,7 +405,10 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
         )}
       </div>
       {photoOpen && (
-        <div className="lightbox-backdrop" onClick={()=>setPhotoOpen(null)}>
+        <div
+          className="lightbox-backdrop"
+          onClick={(e)=>{ e.stopPropagation(); setPhotoOpen(null) }}
+        >
           <img className="lightbox-img" src={photoOpen} alt="pit" />
         </div>
       )}


### PR DESCRIPTION
## Summary
- stop lightbox click from propagating and closing team modal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c37cd053b0832b9f14a8943a062911