### PR TITLE
Use require_once for shared config

### DIFF
--- a/api/client-config.php
+++ b/api/client-config.php
@@ -1,5 +1,5 @@
 <?php
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 
 cors_preflight();
 header('Content-Type: application/json');

--- a/api/dash_export_csv.php
+++ b/api/dash_export_csv.php
@@ -1,7 +1,7 @@
 <?php
 header('Content-Type: text/csv; charset=utf-8');
 header('Content-Disposition: attachment; filename="team_averages.csv"');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/dbinfo.php
+++ b/api/dbinfo.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/pit_photos_list.php
+++ b/api/pit_photos_list.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 try {

--- a/api/statbotics_proxy.php
+++ b/api/statbotics_proxy.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/tba_import.php
+++ b/api/tba_import.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/upload_photo.php
+++ b/api/upload_photo.php
@@ -4,7 +4,7 @@
 // Headers: X-API-KEY (or ?key=...), X-FILENAME (optional filename hint)
 // Query: ?event=2025gaalb&team=1795&name=... (name optional; we'll sanitize)
 
-require __DIR__ . '/config.php'; // db(), cors_preflight(), client_api_key(), $API_KEY
+require_once __DIR__ . '/config.php'; // db(), cors_preflight(), client_api_key(), $API_KEY
 
 // --- CORS ---
 cors_preflight();


### PR DESCRIPTION
## Summary
- Prevent multiple config loads that redeclared helper functions by switching API endpoints to `require_once`
- Resolves fatal error when exporting dashboard data to CSV

## Testing
- `bash tests/upload_photo_no_key.sh`
- `API_KEY=test REQUEST_METHOD=GET php -r '$_GET=["event"=>"a","key"=>"test"]; include "api/dash_export_csv.php";'`

------
https://chatgpt.com/codex/tasks/task_e_68c40ca1d4ac832b83c370c884bc4039