### PR TITLE
Use require_once for shared config and export all dashboard metrics

### DIFF
--- a/api/client-config.php
+++ b/api/client-config.php
@@ -1,5 +1,5 @@
 <?php
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 
 cors_preflight();
 header('Content-Type: application/json');

--- a/api/dash_export_csv.php
+++ b/api/dash_export_csv.php
@@ -1,7 +1,7 @@
 <?php
 header('Content-Type: text/csv; charset=utf-8');
 header('Content-Disposition: attachment; filename="team_averages.csv"');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();
@@ -22,12 +22,57 @@ if (!is_array($js) || empty($js['ok'])) { echo "error"; exit; }
 $teams = $js['teams'] ?? [];
 $metricKeys = $js['stats']['metrics_keys'] ?? [];
 
+// Gather select field options across all teams so each gets a column
+$selectMap = [];
+foreach ($teams as $team) {
+  $sel = $team['select_pct'] ?? [];
+  foreach ($sel as $field => $opts) {
+    foreach ($opts as $opt => $_) {
+      if (!isset($selectMap[$field])) $selectMap[$field] = [];
+      $selectMap[$field][$opt] = true;
+    }
+  }
+  // Legacy endgame_pct field (already included in select_pct but keep just in case)
+  $endSel = $team['endgame_pct'] ?? [];
+  foreach ($endSel as $opt => $_) {
+    if (!isset($selectMap['endgame'])) $selectMap['endgame'] = [];
+    $selectMap['endgame'][$opt] = true;
+  }
+}
+
+$selectKeys = [];
+foreach ($selectMap as $field => $opts) {
+  foreach (array_keys($opts) as $opt) {
+    $selectKeys[] = $field . ':' . $opt;
+  }
+}
+sort($metricKeys);
+sort($selectKeys);
+
 $fh = fopen('php://output', 'w');
-$headers = array_merge(['team_number','nickname','played'], array_map(function($k){ return "avg_" . $k; }, $metricKeys));
-fputcsv($fh, $headers);
+$headers = array_merge(
+  ['team_number','nickname','played'],
+  array_map(function($k){ return 'avg_' . $k; }, $metricKeys),
+  array_map(function($k){ return 'pct_' . $k; }, $selectKeys),
+  ['penalties_avg','driver_skill_avg','defense_played_avg','defended_by_avg','broke_down_pct']
+);
+fputcsv($fh, $headers, ',', chr(34), '\\');
+
 foreach ($teams as $t) {
   $row = [$t['team_number'], $t['nickname'] ?? '', $t['played'] ?? 0];
-  foreach ($metricKeys as $k) { $row[] = $t['avg'][$k] ?? 0; }
-  fputcsv($fh, $row);
+  foreach ($metricKeys as $k) {
+    $row[] = $t['avg'][$k] ?? 0;
+  }
+  foreach ($selectKeys as $k) {
+    $parts = explode(':', $k, 2);
+    $field = $parts[0]; $opt = $parts[1] ?? '';
+    $row[] = $t['select_pct'][$field][$opt] ?? $t['endgame_pct'][$opt] ?? 0;
+  }
+  $row[] = $t['penalties_avg'] ?? 0;
+  $row[] = $t['driver_skill_avg'] ?? 0;
+  $row[] = $t['defense_played_avg'] ?? 0;
+  $row[] = $t['defended_by_avg'] ?? 0;
+  $row[] = $t['broke_down_pct'] ?? 0;
+  fputcsv($fh, $row, ',', chr(34), '\\');
 }
 fclose($fh);

--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/dbinfo.php
+++ b/api/dbinfo.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/pit_photos_list.php
+++ b/api/pit_photos_list.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 try {

--- a/api/statbotics_proxy.php
+++ b/api/statbotics_proxy.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/tba_import.php
+++ b/api/tba_import.php
@@ -1,6 +1,6 @@
 <?php
 header('Content-Type: application/json; charset=utf-8');
-require __DIR__ . '/config.php';
+require_once __DIR__ . '/config.php';
 cors_preflight();
 
 $clientKey = client_api_key();

--- a/api/upload_photo.php
+++ b/api/upload_photo.php
@@ -4,7 +4,7 @@
 // Headers: X-API-KEY (or ?key=...), X-FILENAME (optional filename hint)
 // Query: ?event=2025gaalb&team=1795&name=... (name optional; we'll sanitize)
 
-require __DIR__ . '/config.php'; // db(), cors_preflight(), client_api_key(), $API_KEY
+require_once __DIR__ . '/config.php'; // db(), cors_preflight(), client_api_key(), $API_KEY
 
 // --- CORS ---
 cors_preflight();


### PR DESCRIPTION
## Summary
- Prevent multiple config loads that redeclared helper functions by switching API endpoints to `require_once`
- Resolve fatal error when exporting dashboard data to CSV and include explicit `fputcsv` parameters
- Export all dashboard metrics and selections so the CSV matches the dashboard table

## Testing
- `bash tests/upload_photo_no_key.sh`
- `API_KEY=test REQUEST_METHOD=GET php -r '$_GET=["event"=>"a","key"=>"test"]; include "api/dash_export_csv.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68c40ca1d4ac832b83c370c884bc4039