### PR TITLE
Expand dashboard export to all team metrics

### DIFF
--- a/api/dash_export_csv.php
+++ b/api/dash_export_csv.php
@@ -22,12 +22,40 @@ if (!is_array($js) || empty($js['ok'])) { echo "error"; exit; }
 $teams = $js['teams'] ?? [];
 $metricKeys = $js['stats']['metrics_keys'] ?? [];
 
+// Gather select field options across teams so we can export percent columns
+$selectOpts = [];
+foreach ($teams as $t) {
+  $sel = $t['select_pct'] ?? [];
+  foreach ($sel as $field => $opts) {
+    if (!isset($selectOpts[$field])) $selectOpts[$field] = [];
+    foreach ($opts as $opt => $pct) { $selectOpts[$field][$opt] = true; }
+  }
+}
+ksort($selectOpts); foreach ($selectOpts as $k=>$_) { ksort($selectOpts[$k]); }
+
 $fh = fopen('php://output', 'w');
-$headers = array_merge(['team_number','nickname','played'], array_map(function($k){ return "avg_" . $k; }, $metricKeys));
+$headers = ['team_number','nickname','played'];
+foreach ($metricKeys as $k) { $headers[] = "avg_" . $k; }
+foreach ($selectOpts as $field => $opts) {
+  foreach (array_keys($opts) as $opt) { $headers[] = "pct_{$field}:{$opt}"; }
+}
+$headers = array_merge($headers, [
+  'penalties_avg','driver_skill_avg','defense_played_avg','defended_by_avg','broke_down_pct'
+]);
 fputcsv($fh, $headers, ',', chr(34), '\\');
 foreach ($teams as $t) {
   $row = [$t['team_number'], $t['nickname'] ?? '', $t['played'] ?? 0];
   foreach ($metricKeys as $k) { $row[] = $t['avg'][$k] ?? 0; }
+  foreach ($selectOpts as $field => $opts) {
+    foreach (array_keys($opts) as $opt) {
+      $row[] = $t['select_pct'][$field][$opt] ?? 0;
+    }
+  }
+  $row[] = $t['penalties_avg'] ?? 0;
+  $row[] = $t['driver_skill_avg'] ?? 0;
+  $row[] = $t['defense_played_avg'] ?? 0;
+  $row[] = $t['defended_by_avg'] ?? 0;
+  $row[] = $t['broke_down_pct'] ?? 0;
   fputcsv($fh, $row, ',', chr(34), '\\');
 }
 fclose($fh);


### PR DESCRIPTION
## Summary
- Include select-field percentages and built-in metrics in dashboard CSV export
- Export penalties, driver skill, defense, defended by, and breakdown metrics

## Testing
- `php -l api/dash_export_csv.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c418eaa978832ba2cd8b0313668fec