### PR TITLE
Move logo to footer and show sync status in modal

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -15,6 +15,7 @@ export default function App() {
   const [settings, setSettings] = React.useState<any>(defaultSettings)
   const [syncBusy, setSyncBusy] = React.useState(false)
   const [syncHint, setSyncHint] = React.useState<string>('')
+  const showSyncModal = syncBusy || !!syncHint
   const [envDefaults, setEnvDefaults] = React.useState({
     eventKey: import.meta.env.VITE_EVENT_KEY || '',
     syncUrl: '',
@@ -193,7 +194,6 @@ export default function App() {
   return (
     <SettingsContext.Provider value={{ settings, setSettings }}>
       <div className="nav">
-        <img src={logoImg} alt="Commodore Robotics" className="logo" />
         <button className={`tab ${tab === 'match' ? 'active' : ''}`} onClick={() => setTab('match')}>Match</button>
         <button className={`tab ${tab === 'pit' ? 'active' : ''}`} onClick={() => setTab('pit')}>Pit</button>
         <button className={`tab ${tab === 'dash' ? 'active' : ''}`} onClick={() => setTab('dash')}>Dashboard</button>
@@ -203,10 +203,9 @@ export default function App() {
         <div className="statusline" style={{ marginRight: 8 }}>
           <span className="scout">Scout: {settings.scoutName || '-'}</span>
           <span className="event"> | Event: {settings.eventKey || '-'}</span>
-          {syncHint ? <span role="status" aria-live="polite"> | {syncHint}</span> : null}
         </div>
         <button className="btn" onClick={doUnifiedSync} disabled={syncBusy}>
-          {syncBusy ? (syncHint || 'Syncing...') : 'Sync'}
+          {syncBusy ? 'Syncing...' : 'Sync'}
         </button>
       </div>
 
@@ -269,6 +268,21 @@ export default function App() {
           </div>
         </div>
       )}
+
+      {showSyncModal && (
+        <div className="modal-backdrop">
+          <div className="modal">
+            <div className="header">
+              <h3>Sync Status</h3>
+            </div>
+            <p>{syncHint || 'Syncing...'}</p>
+          </div>
+        </div>
+      )}
+
+      <footer className="footer">
+        <img src={logoImg} alt="Commodore Robotics" className="logo" />
+      </footer>
     </SettingsContext.Provider>
   )
 }

--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -58,7 +58,7 @@ h1, h2, h3, h4, h5, h6,
   max-width: 1000px;
   margin: 0 auto;
 }
-.nav .logo {
+.logo {
   height: 32px;
   width: auto;
 }
@@ -93,6 +93,12 @@ h1, h2, h3, h4, h5, h6,
 }
 @media (max-width: 640px) {
   .statusline .event { display: none; }
+}
+
+.footer {
+  display: flex;
+  justify-content: center;
+  padding: 16px;
 }
 
 /* Modal (Dashboard team view) */


### PR DESCRIPTION
## Summary
- Move branding logo from top nav to a centered footer
- Show sync progress in a modal instead of the nav bar and simplify the sync button
- Add footer styles and global logo styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4212177bc832babf6b030ba5a59e9