### PR TITLE
Improve sync modal and match save flow

### DIFF
--- a/scout/src/pages/MatchForm.tsx
+++ b/scout/src/pages/MatchForm.tsx
@@ -296,6 +296,9 @@ export default function MatchForm() {
             setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefendedBy(0); setDriverSkill(3); setCard('none')
 
             alert(teamNumber ? `Saved for Team ${labelForTeam(teamNumber, teamMeta)}` : 'Saved locally')
+            const nextMatch = localMatch + 1
+            setLocalMatch(nextMatch)
+            setSettings({ ...settings, matchNumber: nextMatch })
           }}
         >
           Save


### PR DESCRIPTION
## Summary
- Remove automatic timeout for sync modal and allow manual closing
- Persist scout name and match number in localStorage
- Increment match number after saving a match

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4237e49f0832b9c97e51af55e5ec1