### PR TITLE
Persist scout name and admin settings

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -3,6 +3,7 @@ import MatchForm from './pages/MatchForm'
 import PitForm from './pages/PitForm'
 import Dashboard from './pages/Dashboard'
 import { SettingsContext, defaultSettings, normalizeSettings, toApiBase } from './settings'
+import type { Settings } from './settings'
 import logoImg from './assets/Commodore_Horizontal_Logo.png'
 import { getAll } from './db'
 import type { PitRecord, MatchRecord } from './db'
@@ -226,7 +227,19 @@ export default function App() {
                 <label>Event Key</label>
                 <input
                   value={settings.eventKey}
-                  onChange={e => setSettings({ ...settings, eventKey: e.target.value })}
+                  onChange={e => {
+                    const val = e.target.value
+                    setSettings((prev: Settings) => {
+                      const next = { ...prev, eventKey: val }
+                      const norm = normalizeSettings(next)
+                      try {
+                        localStorage.setItem('scout:settings', JSON.stringify(norm))
+                        localStorage.setItem('scout:scoutName', norm.scoutName)
+                        localStorage.setItem('scout:matchNumber', String(norm.matchNumber))
+                      } catch {}
+                      return next
+                    })
+                  }}
                   placeholder="e.g., 2025gaalb"
                 />
               </div>
@@ -234,7 +247,19 @@ export default function App() {
                 <label>API Base</label>
                 <input
                   value={settings.syncUrl}
-                  onChange={e => setSettings({ ...settings, syncUrl: e.target.value })}
+                  onChange={e => {
+                    const val = e.target.value
+                    setSettings((prev: Settings) => {
+                      const next = { ...prev, syncUrl: val }
+                      const norm = normalizeSettings(next)
+                      try {
+                        localStorage.setItem('scout:settings', JSON.stringify(norm))
+                        localStorage.setItem('scout:scoutName', norm.scoutName)
+                        localStorage.setItem('scout:matchNumber', String(norm.matchNumber))
+                      } catch {}
+                      return next
+                    })
+                  }}
                   placeholder="https://www.commodorerobotics.com/api"
                 />
               </div>
@@ -243,7 +268,19 @@ export default function App() {
                 <input
                   type="password"
                   value={settings.apiKey}
-                  onChange={e => setSettings({ ...settings, apiKey: e.target.value })}
+                  onChange={e => {
+                    const val = e.target.value
+                    setSettings((prev: Settings) => {
+                      const next = { ...prev, apiKey: val }
+                      const norm = normalizeSettings(next)
+                      try {
+                        localStorage.setItem('scout:settings', JSON.stringify(norm))
+                        localStorage.setItem('scout:scoutName', norm.scoutName)
+                        localStorage.setItem('scout:matchNumber', String(norm.matchNumber))
+                      } catch {}
+                      return next
+                    })
+                  }}
                   placeholder="(secret)"
                 />
               </div>
@@ -257,11 +294,22 @@ export default function App() {
                 <button className="btn" onClick={() => adminPullEvent(true)} title="Re-import even if event exists">
                   Force re-import
                 </button>
-                <button className="btn" onClick={() => {
-                  const url = new URL(window.location.href)
-                  url.searchParams.delete('admin')
-                  window.location.href = url.toString()
-                }}>Close Admin</button>
+                <button
+                  className="btn"
+                  onClick={() => {
+                    const norm = normalizeSettings(settings)
+                    try {
+                      localStorage.setItem('scout:settings', JSON.stringify(norm))
+                      localStorage.setItem('scout:scoutName', norm.scoutName)
+                      localStorage.setItem('scout:matchNumber', String(norm.matchNumber))
+                    } catch {}
+                    const url = new URL(window.location.href)
+                    url.searchParams.delete('admin')
+                    window.location.href = url.toString()
+                  }}
+                >
+                  Close Admin
+                </button>
               </div>
             </div>
 

--- a/scout/src/pages/MatchForm.tsx
+++ b/scout/src/pages/MatchForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { putMatch } from '../db'
 import { SettingsContext } from '../settings'
+import type { Settings } from '../settings'
 import { getGameForEvent } from '../gameConfig'
 import { getCachedSchedule, ScheduleMatch } from '../schedule'
 import { useTeamsMeta } from '../hooks/useTeamsMeta'
@@ -133,7 +134,11 @@ export default function MatchForm() {
         <div className="grid">
           <div className="field">
             <label>Scout</label>
-            <input value={settings.scoutName} onChange={e => setSettings({ ...settings, scoutName: e.target.value })} placeholder="Your name" />
+            <input
+              value={settings.scoutName}
+              onChange={e => setSettings((prev: Settings) => ({ ...prev, scoutName: e.target.value }))}
+              placeholder="Your name"
+            />
           </div>
 
           <div className="field">
@@ -146,7 +151,7 @@ export default function MatchForm() {
                   onClick={() => {
                     const a = sid.startsWith('red') ? 'red' : 'blue'
                     const n = sid.endsWith('1') ? '1' : sid.endsWith('2') ? '2' : '3'
-                    setSettings({ ...settings, alliance: a as Alliance, station: n })
+                    setSettings((prev: Settings) => ({ ...prev, alliance: a as Alliance, station: n }))
                   }}
                 >
                   {sid.startsWith('red') ? 'Red' : 'Blue'} {sid.slice(-1)}
@@ -158,9 +163,32 @@ export default function MatchForm() {
           <div className="field">
             <label>Match #</label>
             <div className="row nowrap">
-              <button className="btn" onClick={() => { const n = Math.max(1, localMatch - 1); setLocalMatch(n); setSettings({ ...settings, matchNumber: n }) }}>-</button>
-              <input inputMode="numeric" value={localMatch} onChange={e => { const n = Math.max(1, Number(e.target.value || 1)); setLocalMatch(n); setSettings({ ...settings, matchNumber: n }) }} placeholder="1" />
-              <button className="btn" onClick={() => { const n = localMatch + 1; setLocalMatch(n); setSettings({ ...settings, matchNumber: n }) }}>+</button>
+              <button
+                className="btn"
+                onClick={() => {
+                  const n = Math.max(1, localMatch - 1)
+                  setLocalMatch(n)
+                  setSettings((prev: Settings) => ({ ...prev, matchNumber: n }))
+                }}
+              >-</button>
+              <input
+                inputMode="numeric"
+                value={localMatch}
+                onChange={e => {
+                  const n = Math.max(1, Number(e.target.value || 1))
+                  setLocalMatch(n)
+                  setSettings((prev: Settings) => ({ ...prev, matchNumber: n }))
+                }}
+                placeholder="1"
+              />
+              <button
+                className="btn"
+                onClick={() => {
+                  const n = localMatch + 1
+                  setLocalMatch(n)
+                  setSettings((prev: Settings) => ({ ...prev, matchNumber: n }))
+                }}
+              >+</button>
             </div>
           </div>
 
@@ -298,7 +326,7 @@ export default function MatchForm() {
             alert(teamNumber ? `Saved for Team ${labelForTeam(teamNumber, teamMeta)}` : 'Saved locally')
             const nextMatch = localMatch + 1
             setLocalMatch(nextMatch)
-            setSettings({ ...settings, matchNumber: nextMatch })
+            setSettings((prev: Settings) => ({ ...prev, matchNumber: nextMatch }))
           }}
         >
           Save

--- a/scout/src/settings.ts
+++ b/scout/src/settings.ts
@@ -93,8 +93,9 @@ export const defaultSettings: Settings = normalizeSettings({
 // Public context
 export const SettingsContext = React.createContext<{
   settings: Settings
-  setSettings: (s: Settings) => void
+  setSettings: React.Dispatch<React.SetStateAction<Settings>>
 }>({
   settings: defaultSettings,
-  setSettings: () => {}
+  // cast default setter to any to satisfy context initialization
+  setSettings: (() => {}) as any
 })


### PR DESCRIPTION
## Summary
- Fix match form to keep the scout name when saving and moving to the next match
- Save admin page settings immediately and on close so event key persists across reloads
- Allow SettingsContext to accept functional updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c426903118832b8a8b3c3b2719a5eb