### PR TITLE
fix: delay settings persistence until loaded

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
     syncUrl: '',
     apiKey: import.meta.env.VITE_API_KEY || ''
   })
+  const [settingsLoaded, setSettingsLoaded] = React.useState(false)
 
   // Load saved settings once — and force-merge env defaults into blanks
   React.useEffect(() => {
@@ -57,11 +58,13 @@ export default function App() {
       } catch {
         setSettings(normalizeSettings(fillBlanks({})))
       }
+      setSettingsLoaded(true)
     })()
   }, [])
 
   // Persist settings on change (normalize again to be safe)
   React.useEffect(() => {
+    if (!settingsLoaded) return
     try {
       const filled = {
         ...settings,
@@ -75,7 +78,7 @@ export default function App() {
       localStorage.setItem('scout:matchNumber', String(norm.matchNumber))
       if (JSON.stringify(norm) !== JSON.stringify(settings)) setSettings(norm)
     } catch {}
-  }, [settings, envDefaults])
+  }, [settings, envDefaults, settingsLoaded])
 
   // Hidden admin via ?admin=1
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- add `settingsLoaded` flag to avoid overwriting stored settings before load
- persist settings only after initial load completes

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`
- `npx playwright --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c42acf3930832b975a342dc423e4f0