### PR TITLE
Avoid page reload when leaving Admin

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -308,7 +308,8 @@ export default function App() {
                     } catch {}
                     const url = new URL(window.location.href)
                     url.searchParams.delete('admin')
-                    window.location.href = url.toString()
+                    setTab('match')
+                    window.history.replaceState(null, '', url.toString())
                   }}
                 >
                   Close Admin


### PR DESCRIPTION
## Summary
- Exit Admin tab without full reload and remove ?admin=1 via history API
- Ensure settings persist only after initial load so event key survives reloads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c42c40d168832ba21d26de8d973675