### PR TITLE
Normalize sync URL protocol for HTTPS

### DIFF
--- a/scout/src/settings.ts
+++ b/scout/src/settings.ts
@@ -29,10 +29,17 @@ function isBlank(v: any) {
 // Normalize to .../api (accepts root, /api, or /api/sync.php)
 export function toApiBase(url: string): string {
   const clean = (url || '').trim().replace(/\/+$/,'')
-  if (!clean) return '/api'
-  if (/\/sync\.php$/i.test(clean)) return clean.replace(/\/sync\.php$/i, '')
-  if (/\/api$/i.test(clean)) return clean
-  return clean + '/api'
+  const parsed = new URL(clean || '/', window.location.origin)
+  if (window.location.protocol === 'https:' && parsed.protocol === 'http:') {
+    parsed.protocol = 'https:'
+  }
+  let path = parsed.pathname.replace(/\/+$/,'')
+  if (/\/sync\.php$/i.test(path)) path = path.replace(/\/sync\.php$/i, '')
+  if (!/\/api$/i.test(path)) path = path + '/api'
+  parsed.pathname = path
+  parsed.search = ''
+  parsed.hash = ''
+  return parsed.toString()
 }
 
 function ensureDeviceId(existing?: string): string {


### PR DESCRIPTION
## Summary
- Ensure toApiBase parses URLs via `new URL` and upgrades to HTTPS when the app is served securely
- Normalize sync URLs to an `/api` base path free of trailing query/hash

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c42dbfee50832b8f803d0eef8d6b0b