### PR TITLE
style: wrap navbar on small screens

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -207,7 +207,7 @@ export default function App() {
 
         <div className="spacer" />
 
-        <div className="statusline" style={{ marginRight: 8 }}>
+        <div className="statusline">
           <span className="scout">Scout: {settings.scoutName || '-'}</span>
           <span className="event"> | Event: {settings.eventKey || '-'}</span>
         </div>

--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -54,6 +54,9 @@ h1, h2, h3, h4, h5, h6,
   backdrop-filter: blur(8px);
   border-bottom: 1px solid rgba(255,255,255,0.06);
 
+  /* allow wrapping on small screens */
+  flex-wrap: wrap;
+
   /* match container width without needing extra wrapper */
   max-width: 1000px;
   margin: 0 auto;
@@ -91,8 +94,15 @@ h1, h2, h3, h4, h5, h6,
   font-size: 0.9rem;
   white-space: nowrap;
 }
+.nav .statusline { margin-right: 8px; }
+
 @media (max-width: 640px) {
-  .statusline .event { display: none; }
+  .nav .statusline {
+    order: 1;
+    flex-basis: 100%;
+    margin: 4px 0 0;
+    text-align: center;
+  }
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- Allow top nav to wrap on small screens
- Display scout and event info on a second row on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c42f12e098832bb8f7baa975ed62eb