### PR TITLE
feat: add password prompt to scout app

### DIFF
--- a/scout/src/PasswordGate.tsx
+++ b/scout/src/PasswordGate.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { appConfig } from './appConfig'
+
+const PASSWORD_TIMEOUT_MS = 3 * 60 * 60 * 1000 // 3 hours
+
+export default function PasswordGate({ children }: { children: React.ReactNode }) {
+  const [authed, setAuthed] = React.useState(false)
+  const [pw, setPw] = React.useState('')
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const last = Number(localStorage.getItem('scout:authTime') || '0')
+    if (appConfig.APP_PASSWORD === '' || (last && Date.now() - last < PASSWORD_TIMEOUT_MS)) {
+      setAuthed(true)
+    }
+  }, [])
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (pw === appConfig.APP_PASSWORD) {
+      localStorage.setItem('scout:authTime', String(Date.now()))
+      setAuthed(true)
+      setError(null)
+    } else {
+      setError('Incorrect password')
+    }
+  }
+
+  if (authed) return <>{children}</>
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <form
+        onSubmit={submit}
+        style={{ background: 'white', padding: '1rem', borderRadius: '4px' }}
+      >
+        <p>Please enter the password:</p>
+        <input
+          type="password"
+          value={pw}
+          onChange={e => setPw(e.target.value)}
+          style={{ marginBottom: '0.5rem', width: '100%' }}
+        />
+        {error && <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>}
+        <button type="submit">Enter</button>
+      </form>
+    </div>
+  )
+}
+

--- a/scout/src/appConfig.ts
+++ b/scout/src/appConfig.ts
@@ -1,3 +1,4 @@
 export const appConfig = {
-  EVENT_KEY: import.meta.env.VITE_EVENT_KEY ?? ''
+  EVENT_KEY: import.meta.env.VITE_EVENT_KEY ?? '',
+  APP_PASSWORD: import.meta.env.VITE_APP_PASSWORD ?? 'scout'
 }

--- a/scout/src/main.tsx
+++ b/scout/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import PasswordGate from './PasswordGate'
 import './styles.css'
 import { registerSW } from './sw-register'
 
@@ -11,7 +12,9 @@ const root = createRoot(document.getElementById('root')!)
 root.render(
   <React.StrictMode>
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <App />
+      <PasswordGate>
+        <App />
+      </PasswordGate>
     </BrowserRouter>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- gate app with simple password prompt using localStorage timestamp
- add configurable APP_PASSWORD via env variable (default `scout`)

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c457a2e860832b93a5bb55df22919e