### PR TITLE
feat: add pit export csv

### DIFF
--- a/api/pit_export_csv.php
+++ b/api/pit_export_csv.php
@@ -1,0 +1,53 @@
+<?php
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="pit_scouting.csv"');
+require_once __DIR__ . '/config.php';
+cors_preflight();
+
+$clientKey = client_api_key();
+global $API_KEY;
+if (!isset($API_KEY) || !$clientKey || !hash_equals($API_KEY, $clientKey)) {
+  http_response_code(401); echo "unauthorized"; exit;
+}
+
+$event = strtolower(trim($_GET['event'] ?? ''));
+if ($event === '') { http_response_code(400); echo "missing_event"; exit; }
+
+$pdo = db();
+$stmt = $pdo->prepare(
+  "SELECT team_number, drivetrain, weight_lb, dims_json, autos, mechanisms_json, notes, photos_json, scout_name, device_id, created_at_ms, schema_version FROM pit_records WHERE event_key = :event ORDER BY team_number"
+);
+$stmt->execute([':event' => $event]);
+
+$fh = fopen('php://output', 'w');
+$headers = ['team_number','drivetrain','weight_lb','dim_h','dim_w','dim_l','autos','mechanisms','notes','photos_json','scout_name','device_id','created_at_ms','schema_version'];
+fputcsv($fh, $headers, ',', chr(34), '\\');
+
+while ($r = $stmt->fetch(PDO::FETCH_ASSOC)) {
+  $dims = json_decode($r['dims_json'] ?? '', true) ?: [];
+  $mech = json_decode($r['mechanisms_json'] ?? '', true);
+  $mechanisms = '';
+  if (is_array($mech)) {
+    if (array_key_exists('text', $mech)) $mechanisms = $mech['text'];
+    else $mechanisms = json_encode($mech, JSON_UNESCAPED_SLASHES);
+  }
+  $row = [
+    $r['team_number'],
+    $r['drivetrain'],
+    $r['weight_lb'],
+    $dims['h'] ?? '',
+    $dims['w'] ?? '',
+    $dims['l'] ?? '',
+    $r['autos'],
+    $mechanisms,
+    $r['notes'],
+    $r['photos_json'],
+    $r['scout_name'],
+    $r['device_id'],
+    $r['created_at_ms'],
+    $r['schema_version'],
+  ];
+  fputcsv($fh, $row, ',', chr(34), '\\');
+}
+fclose($fh);
+

--- a/scout/src/pages/PitForm.tsx
+++ b/scout/src/pages/PitForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { putPit } from '../db'
-import { SettingsContext } from '../settings'
+import { SettingsContext, toApiBase } from '../settings'
 import { getGameForEvent } from '../gameConfig'
 import { useTeamsMeta } from '../hooks/useTeamsMeta'
 
@@ -19,6 +19,8 @@ export default function PitForm() {
   const { settings } = React.useContext(SettingsContext)
   const game = getGameForEvent(settings.eventKey)
   const schemaVersion = Number((game as any)?.schema) || 1
+  const base = toApiBase(settings.syncUrl)
+  const exportHref = `${base}/pit_export_csv.php?event=${encodeURIComponent(settings.eventKey)}&key=${encodeURIComponent(settings.apiKey)}`
 
   // Local form state
   const [teamNumber, setTeamNumber] = useState<number | ''>('')
@@ -67,7 +69,10 @@ export default function PitForm() {
 
   return (
     <div className="container">
-      <h2>{game.name} - Pit Scouting</h2>
+      <div className="row" style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2>{game.name} - Pit Scouting</h2>
+        <a className="btn" href={exportHref}>Export CSV</a>
+      </div>
 
       {/* Team + basics */}
       <div className="card">


### PR DESCRIPTION
## Summary
- add API endpoint to export pit scouting records as CSV
- add export CSV button to pit scouting form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `php -l ../api/pit_export_csv.php`

------
https://chatgpt.com/codex/tasks/task_e_68c47a6897d0832baab7571b6f3178a0