### PR TITLE
Rename defended_by to defense_resilience

### DIFF
--- a/2024gaalb_test_data.sql
+++ b/2024gaalb_test_data.sql
@@ -6,7 +6,7 @@ START TRANSACTION;
 -- Match records
 INSERT INTO match_records
 (match_key, alliance, position, team_number, metrics_json,
- penalties, broke_down, defense_played, defended_by, driver_skill,
+ penalties, broke_down, defense_played, defense_resilience, driver_skill,
  card, comments, scout_name, device_id, created_at_ms, schema_version)
 SELECT match_key,
        alliance,
@@ -32,7 +32,7 @@ SELECT match_key,
        RAND()<0.05 AS broke_down,
        CASE WHEN team_number IN (4509,5074) THEN FLOOR(RAND()*4)+2
             ELSE FLOOR(RAND()*3) END AS defense_played,
-       FLOOR(RAND()*4) AS defended_by,
+       FLOOR(RAND()*4) AS defense_resilience,
        FLOOR(RAND()*5)+1 AS driver_skill,
        CASE
          WHEN team_number=3329 AND match_number=14 THEN 'yellow'

--- a/2025gaalb_test_data.sql
+++ b/2025gaalb_test_data.sql
@@ -1,7 +1,7 @@
 DELETE FROM match_records WHERE match_key LIKE '2025gaalb%';
 DELETE FROM pit_records WHERE event_key='2025gaalb';
 
-INSERT INTO match_records (match_key, alliance, position, team_number, metrics_json, penalties, broke_down, defense_played, defended_by, driver_skill, card, comments, scout_name, device_id, created_at_ms, schema_version) VALUES
+INSERT INTO match_records (match_key, alliance, position, team_number, metrics_json, penalties, broke_down, defense_played, defense_resilience, driver_skill, card, comments, scout_name, device_id, created_at_ms, schema_version) VALUES
 ('2025gaalb_qm1','red','red1',1002,'{"auto_coral_L1": 0, "auto_coral_L2": 0, "auto_coral_L3": 0, "auto_coral_L4": 1, "auto_algae_scored": 1, "auto_mobility": true, "teleop_coral_L1": 1, "teleop_coral_L2": 1, "teleop_coral_L3": 2, "teleop_coral_L4": 4, "teleop_algae_scored": 2, "teleop_dropped": 1, "endgame_climb": "none", "coop": true}',0,1,2,2,3,'none','generated','AutoGen','dev_sim',0,2),
 ('2025gaalb_qm1','red','red2',4240,'{"auto_coral_L1": 0, "auto_coral_L2": 2, "auto_coral_L3": 2, "auto_coral_L4": 1, "auto_algae_scored": 1, "auto_mobility": false, "teleop_coral_L1": 2, "teleop_coral_L2": 1, "teleop_coral_L3": 1, "teleop_coral_L4": 2, "teleop_algae_scored": 0, "teleop_dropped": 2, "endgame_climb": "none", "coop": false}',1,0,0,1,2,'none','generated','AutoGen','dev_sim',0,2),
 ('2025gaalb_qm1','red','red3',5828,'{"auto_coral_L1": 2, "auto_coral_L2": 0, "auto_coral_L3": 1, "auto_coral_L4": 2, "auto_algae_scored": 0, "auto_mobility": true, "teleop_coral_L1": 1, "teleop_coral_L2": 0, "teleop_coral_L3": 0, "teleop_coral_L4": 1, "teleop_algae_scored": 0, "teleop_dropped": 1, "endgame_climb": "none", "coop": false}',0,0,2,0,4,'none','generated','AutoGen','dev_sim',0,2),

--- a/api/dash_export_csv.php
+++ b/api/dash_export_csv.php
@@ -40,7 +40,7 @@ foreach ($selectOpts as $field => $opts) {
   foreach (array_keys($opts) as $opt) { $headers[] = "pct_{$field}:{$opt}"; }
 }
 $headers = array_merge($headers, [
-  'penalties_avg','driver_skill_avg','defense_played_avg','defended_by_avg','broke_down_pct'
+  'penalties_avg','driver_skill_avg','defense_played_avg','defense_resilience_avg','broke_down_pct'
 ]);
 fputcsv($fh, $headers, ',', chr(34), '\\');
 foreach ($teams as $t) {
@@ -54,7 +54,7 @@ foreach ($teams as $t) {
   $row[] = $t['penalties_avg'] ?? 0;
   $row[] = $t['driver_skill_avg'] ?? 0;
   $row[] = $t['defense_played_avg'] ?? 0;
-  $row[] = $t['defended_by_avg'] ?? 0;
+  $row[] = $t['defense_resilience_avg'] ?? 0;
   $row[] = $t['broke_down_pct'] ?? 0;
   fputcsv($fh, $row, ',', chr(34), '\\');
 }

--- a/api/dash_summary.php
+++ b/api/dash_summary.php
@@ -39,7 +39,7 @@ try {
         'card' => [],
         'driver_skill_sum' => 0,
         'defense_played_sum' => 0,
-        'defended_by_sum' => 0,
+        'defense_resilience_sum' => 0,
         'broke_down_sum' => 0,
       ];
     }
@@ -96,7 +96,7 @@ try {
 
     $teamsAgg[$tnum]['driver_skill_sum'] += (int)($r['driver_skill'] ?? 0);
     $teamsAgg[$tnum]['defense_played_sum'] += (int)($r['defense_played'] ?? 0);
-    $teamsAgg[$tnum]['defended_by_sum'] += (int)($r['defended_by'] ?? 0);
+    $teamsAgg[$tnum]['defense_resilience_sum'] += (int)($r['defense_resilience'] ?? 0);
 
     $recent[] = [
       'match_key' => $r['match_key'], 'team_number' => $tnum, 'alliance' => $r['alliance'],
@@ -162,7 +162,7 @@ try {
       'penalties_avg' => round($agg['penalties_sum'] / $played, 2),
       'driver_skill_avg' => round($agg['driver_skill_sum'] / $played, 2),
       'defense_played_avg' => round($agg['defense_played_sum'] / $played, 2),
-      'defended_by_avg' => round($agg['defended_by_sum'] / $played, 2),
+      'defense_resilience_avg' => round($agg['defense_resilience_sum'] / $played, 2),
       'broke_down_pct' => round(100.0 * $agg['broke_down_sum'] / $played, 1),
     ];
   }

--- a/api/sync.php
+++ b/api/sync.php
@@ -143,12 +143,12 @@ if (!empty($match)) {
     INSERT INTO match_records
       (match_key, alliance, position, team_number,
        metrics_json,
-       penalties, broke_down, defense_played, defended_by, driver_skill, card, comments,
+       penalties, broke_down, defense_played, defense_resilience, driver_skill, card, comments,
        scout_name, device_id, created_at_ms, schema_version)
     VALUES
       (:match_key, :alliance, :position, :team_number,
        :metrics_json,
-       :penalties, :broke_down, :defense_played, :defended_by, :driver_skill, :card, :comments,
+       :penalties, :broke_down, :defense_played, :defense_resilience, :driver_skill, :card, :comments,
        :scout_name, :device_id, :created_at_ms, :schema_version)
     ON DUPLICATE KEY UPDATE
        alliance        = VALUES(alliance),
@@ -157,7 +157,7 @@ if (!empty($match)) {
        penalties       = VALUES(penalties),
        broke_down      = VALUES(broke_down),
        defense_played  = VALUES(defense_played),
-       defended_by     = VALUES(defended_by),
+       defense_resilience = VALUES(defense_resilience),
        driver_skill    = VALUES(driver_skill),
        card            = VALUES(card),
        comments        = VALUES(comments),
@@ -188,7 +188,7 @@ if (!empty($match)) {
     $penalties    = to_int($r['penalties'] ?? 0);
     $broke_down   = to_bool01($r['brokeDown'] ?? 0);
     $def_played   = to_int($r['defensePlayed'] ?? 0);
-    $def_by       = to_int($r['defendedBy'] ?? 0);
+    $def_resilience = to_int($r['defenseResilience'] ?? 0);
     $driver_skill = to_int($r['driverSkill'] ?? 0);
     $card         = to_str_or_null($r['card'] ?? null);
     $comments     = to_str_or_null($r['comments'] ?? null);
@@ -207,7 +207,7 @@ if (!empty($match)) {
       ':penalties'      => $penalties,
       ':broke_down'     => $broke_down,
       ':defense_played' => $def_played,
-      ':defended_by'    => $def_by,
+      ':defense_resilience' => $def_resilience,
       ':driver_skill'   => $driver_skill,
       ':card'           => $card,
       ':comments'       => $comments,

--- a/api/team_detail.php
+++ b/api/team_detail.php
@@ -38,7 +38,7 @@ try {
   $stmt = $pdo->prepare("
     SELECT match_key, alliance, position, team_number,
            metrics_json, penalties, broke_down,
-           defense_played, defended_by, driver_skill, card,
+           defense_played, defense_resilience, driver_skill, card,
            comments, scout_name, device_id, created_at_ms, schema_version
     FROM match_records
     WHERE team_number = ?
@@ -79,14 +79,14 @@ try {
       AVG(NULLIF(penalties, NULL))       AS penalties_avg,
       AVG(NULLIF(driver_skill, NULL))    AS driver_skill_avg,
       COALESCE(AVG(broke_down), 0)       AS broke_down_avg,
-      COALESCE(AVG(defended_by), 0)      AS defended_by_avg,
+      COALESCE(AVG(defense_resilience), 0) AS defense_resilience_avg,
       COALESCE(AVG(defense_played), 0)   AS defense_played_avg
     FROM match_records
     WHERE team_number = ?
       AND match_key LIKE CONCAT(?, '_%')
   ");
   $stmt->execute([$team, $event]);
-  $agg = $stmt->fetch() ?: ['played'=>0,'penalties_avg'=>null,'driver_skill_avg'=>null,'broke_down_avg'=>0,'defended_by_avg'=>0,'defense_played_avg'=>0];
+  $agg = $stmt->fetch() ?: ['played'=>0,'penalties_avg'=>null,'driver_skill_avg'=>null,'broke_down_avg'=>0,'defense_resilience_avg'=>0,'defense_played_avg'=>0];
 
   // --- Cards received (distinct)
   $stmt = $pdo->prepare("
@@ -177,7 +177,7 @@ try {
     'penalties_avg' => $agg['penalties_avg'] !== null ? round(floatval($agg['penalties_avg']), 2) : null,
     'driver_skill_avg' => $agg['driver_skill_avg'] !== null ? round(floatval($agg['driver_skill_avg']), 2) : null,
     'broke_down_avg' => round(floatval($agg['broke_down_avg'] ?? 0), 2),
-    'defended_by_avg' => round(floatval($agg['defended_by_avg'] ?? 0), 2),
+    'defense_resilience_avg' => round(floatval($agg['defense_resilience_avg'] ?? 0), 2),
     'defense_played_avg' => round(floatval($agg['defense_played_avg'] ?? 0), 2),
     'cards' => $cards,
     'flags_pct' => (object)$flagsPct,

--- a/migrations/rename_defended_by.sql
+++ b/migrations/rename_defended_by.sql
@@ -1,0 +1,2 @@
+ALTER TABLE match_records
+  CHANGE defended_by defense_resilience TINYINT(3) UNSIGNED DEFAULT NULL;

--- a/schema.sql
+++ b/schema.sql
@@ -58,7 +58,7 @@ CREATE TABLE `match_records` (
   `penalties` int(10) UNSIGNED DEFAULT NULL,
   `broke_down` tinyint(1) DEFAULT NULL,
   `defense_played` tinyint(3) UNSIGNED DEFAULT NULL,
-  `defended_by` tinyint(3) UNSIGNED DEFAULT NULL,
+  `defense_resilience` tinyint(3) UNSIGNED DEFAULT NULL,
   `driver_skill` tinyint(3) UNSIGNED DEFAULT NULL,
   `card` varchar(16) DEFAULT NULL,
   `comments` text DEFAULT NULL,

--- a/scout/src/db.ts
+++ b/scout/src/db.ts
@@ -33,7 +33,7 @@ export type MatchRecord = {
   penalties?: number
   brokeDown?: boolean
   defensePlayed?: number
-  defendedBy?: number
+  defenseResilience?: number
   driverSkill?: number
   card?: 'none'|'yellow'|'red'
   comments?: string

--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -16,7 +16,7 @@ type DashTeam = {
   penalties_avg?: number
   driver_skill_avg?: number
   defense_played_avg?: number
-  defended_by_avg?: number
+  defense_resilience_avg?: number
   broke_down_pct?: number
 }
 
@@ -102,7 +102,7 @@ export default function Dashboard() {
       { key: 'penalties', label: 'Penalties', percent: false },
       { key: 'broke_down', label: 'Broke Down', percent: true },
       { key: 'defense_played', label: 'Defense Played', percent: false },
-      { key: 'defended_by', label: 'Defended By', percent: false },
+      { key: 'defense_resilience', label: 'Defense Resilience', percent: false },
       { key: 'driver_skill', label: 'Driver Skill', percent: false },
     )
     return defs
@@ -180,7 +180,7 @@ export default function Dashboard() {
     if (k === 'penalties') return t.penalties_avg ?? 0
     if (k === 'driver_skill') return t.driver_skill_avg ?? 0
     if (k === 'defense_played') return t.defense_played_avg ?? 0
-    if (k === 'defended_by') return t.defended_by_avg ?? 0
+    if (k === 'defense_resilience') return t.defense_resilience_avg ?? 0
     if (k === 'broke_down') return t.broke_down_pct ?? 0
     const sel = selectMetricMap[k]
     if (sel) return t.select_pct?.[sel.field]?.[sel.option] ?? 0
@@ -394,7 +394,7 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
                 </ul>
               )}
               <p className="help">
-                Played: {detail?.played ?? 0} · Penalties Avg: {fmt(detail?.penalties_avg)} · Driver Avg: {fmt(detail?.driver_skill_avg)} · Broke Down Avg: {fmt(detail?.broke_down_avg)} · Defended By Avg: {fmt(detail?.defended_by_avg)} · Defense Played Avg: {fmt(detail?.defense_played_avg)}
+                Played: {detail?.played ?? 0} · Penalties Avg: {fmt(detail?.penalties_avg)} · Driver Avg: {fmt(detail?.driver_skill_avg)} · Broke Down Avg: {fmt(detail?.broke_down_avg)} · Defense Resilience Avg: {fmt(detail?.defense_resilience_avg)} · Defense Played Avg: {fmt(detail?.defense_played_avg)}
               </p>
               {detail?.cards && detail.cards.length > 0 && (
                 <p className="help">Cards: {detail.cards.join(', ')}</p>

--- a/scout/src/pages/MatchForm.tsx
+++ b/scout/src/pages/MatchForm.tsx
@@ -109,7 +109,7 @@ export default function MatchForm() {
   const [penalties, setPenalties] = useState(0)
   const [brokeDown, setBrokeDown] = useState(false)
   const [defensePlayed, setDefensePlayed] = useState(0)
-  const [defendedBy, setDefendedBy] = useState(0)
+  const [defenseResilience, setDefenseResilience] = useState(0)
   const [driverSkill, setDriverSkill] = useState(3)
   const [card, setCard] = useState<'none'|'yellow'|'red'>('none')
 
@@ -123,7 +123,7 @@ export default function MatchForm() {
     return false
   }
   function resetDiscipline() {
-    setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefendedBy(0); setDriverSkill(3); setCard('none')
+    setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefenseResilience(0); setDriverSkill(3); setCard('none')
   }
 
   return (
@@ -262,8 +262,8 @@ export default function MatchForm() {
           <input type="range" min={0} max={5} step={1} value={defensePlayed} onChange={e => setDefensePlayed(parseInt(e.target.value, 10))} />
         </div>
         <div className="field">
-          <label>Defended By: <span className="muted">{defendedBy}</span></label>
-          <input type="range" min={0} max={5} step={1} value={defendedBy} onChange={e => setDefendedBy(parseInt(e.target.value, 10))} />
+          <label>Defense Resilience: <span className="muted">{defenseResilience}</span></label>
+          <input type="range" min={0} max={5} step={1} value={defenseResilience} onChange={e => setDefenseResilience(parseInt(e.target.value, 10))} />
         </div>
         <div className="field">
           <label>Driver Skill: <span className="muted">{driverSkill}</span></label>
@@ -293,7 +293,7 @@ export default function MatchForm() {
           onClick={async () => {
             const _pen = Math.max(0, Number.isFinite(penalties) ? Math.floor(penalties) : 0)
             const _defPlayed = Math.max(0, Math.min(5, Number.isFinite(defensePlayed) ? Math.floor(defensePlayed) : 0))
-            const _defBy = Math.max(0, Math.min(5, Number.isFinite(defendedBy) ? Math.floor(defendedBy) : 0))
+            const _defRes = Math.max(0, Math.min(5, Number.isFinite(defenseResilience) ? Math.floor(defenseResilience) : 0))
             const _drv = Math.max(1, Math.min(5, Number.isFinite(driverSkill) ? Math.floor(driverSkill) : 3))
 
             const { notes, ...metricsForSave } = metrics
@@ -308,7 +308,7 @@ export default function MatchForm() {
               penalties: _pen,
               brokeDown,
               defensePlayed: _defPlayed,
-              defendedBy: _defBy,
+              defenseResilience: _defRes,
               driverSkill: _drv,
               card,
               comments: String(metrics['notes'] ?? '') || undefined,
@@ -321,7 +321,7 @@ export default function MatchForm() {
 
             // reset UI
             setMetrics(initialMetrics)
-            setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefendedBy(0); setDriverSkill(3); setCard('none')
+            setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefenseResilience(0); setDriverSkill(3); setCard('none')
 
             alert(teamNumber ? `Saved for Team ${labelForTeam(teamNumber, teamMeta)}` : 'Saved locally')
             const nextMatch = localMatch + 1


### PR DESCRIPTION
## Summary
- rename defended_by column to defense_resilience and add migration script
- update PHP API endpoints and CSV export for defense_resilience
- adjust TypeScript types and React UI for "Defense Resilience"

## Testing
- `npm test --prefix scout` *(fails: Missing script: "test")*
- `npm run build --prefix scout`

------
https://chatgpt.com/codex/tasks/task_e_68c4c774470c832b87785df3d0ae0505