### PR TITLE
style: add spacing between cards

### DIFF
--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -232,7 +232,7 @@ export default function Dashboard() {
         {error && <div className="error" role="alert">Error: {error}</div>}
 
         {/* Column selector */}
-        <div className="card" style={{ marginTop: 8 }}>
+        <div className="card">
           <div className="row" style={{ justifyContent: 'space-between' }}>
             <div className="help">Columns: choose which averages to display</div>
             <div className="row">

--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -167,6 +167,9 @@ h1, h2, h3, h4, h5, h6,
   padding: 16px;
   min-width: 0;
 }
+.card + .card {
+  margin-top: 16px;
+}
 .grid { display: grid; gap: 12px; }
 .grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
 .grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }


### PR DESCRIPTION
## Summary
- add sibling margin rule so stacked cards have consistent spacing
- remove inline Dashboard card margin in favor of shared CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd7af878832ba0131e6f6854933b