### PR TITLE
Display logo in password gate modal

### DIFF
--- a/scout/src/PasswordGate.tsx
+++ b/scout/src/PasswordGate.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { appConfig } from './appConfig'
+import logo from './assets/logo.png'
 
 const PASSWORD_TIMEOUT_MS = 3 * 60 * 60 * 1000 // 3 hours
 
@@ -31,6 +32,7 @@ export default function PasswordGate({ children }: { children: React.ReactNode }
   return (
     <div className="modal-backdrop">
       <form className="modal" onSubmit={submit}>
+        <img src={logo} alt="Commodore logo" className="logo" />
         <div className="field">
           <label htmlFor="pw">Please enter the password:</label>
           <input

--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -151,6 +151,10 @@ h1, h2, h3, h4, h5, h6,
   overflow: auto;
   padding: 16px;
 }
+.modal .logo {
+  display: block;
+  margin: 0 auto 16px;
+}
 .modal .header { display:flex; align-items:center; justify-content: space-between; gap: 8px; }
 .modal .close { background: transparent; border: 1px solid var(--border); border-radius: 10px; padding: 6px 10px; cursor: pointer; }
 .clickable { cursor: pointer; text-decoration: underline; text-underline-offset: 3px; }


### PR DESCRIPTION
## Summary
- Show Commodore logo above password form
- Center logo in modal with new CSS rule

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4ce811d50832ba0aaed61b9f8bc13