### PR TITLE
Add alternating dashboard row colors and centralize styles

### DIFF
--- a/scout/src/App.tsx
+++ b/scout/src/App.tsx
@@ -317,7 +317,7 @@ export default function App() {
               </div>
             </div>
 
-            <p className="help" style={{ marginTop: 8 }}>
+            <p className="help mt-8">
               Admin is hidden from nav. Open with <code>?admin=1</code>. "Pull Event Data" will create teams & schedule on the server if missing, then refresh the app cache.
             </p>
           </div>

--- a/scout/src/PasswordGate.tsx
+++ b/scout/src/PasswordGate.tsx
@@ -48,7 +48,7 @@ export default function PasswordGate({ children }: { children: React.ReactNode }
             {error}
           </div>
         )}
-        <div className="row" style={{ justifyContent: 'flex-end', marginTop: 8 }}>
+        <div className="row justify-end mt-8">
           <button type="submit" className="btn primary">
             Enter
           </button>

--- a/scout/src/pages/Dashboard.tsx
+++ b/scout/src/pages/Dashboard.tsx
@@ -219,21 +219,21 @@ export default function Dashboard() {
   return (
     <div className="container">
       <div className="card">
-        <div className="row" style={{ alignItems: 'center', justifyContent: 'space-between' }}>
-          <h3 style={{ margin: 0 }}>Dashboard</h3>
+        <div className="row between">
+          <h3 className="no-margin">Dashboard</h3>
           <div>
             <button className="btn" onClick={load} disabled={loading}>{loading ? 'Loading…' : 'Refresh'}</button>
-            <a className="btn" href={exportHref} style={{ marginLeft: 8 }}>Export CSV</a>
+            <a className="btn ml-8" href={exportHref}>Export CSV</a>
           </div>
         </div>
-        <p className="help" style={{ marginTop: 8 }}>
+        <p className="help mt-8">
           Event: <strong>{settings.eventKey || '-'}</strong> · Teams: {data?.stats?.teams ?? '-'} · Matches: {data?.stats?.matches ?? '-'}
         </p>
         {error && <div className="error" role="alert">Error: {error}</div>}
 
         {/* Column selector */}
         <div className="card">
-          <div className="row" style={{ justifyContent: 'space-between' }}>
+          <div className="row between">
             <div className="help">Columns: choose which averages to display</div>
             <div className="row">
               <button className="btn" onClick={()=>setAllMetrics(true)}>All</button>
@@ -246,9 +246,9 @@ export default function Dashboard() {
             </div>
           </div>
           {showColumnChooser && (
-            <div className="row" style={{ gap: 12, marginTop: 8, flexWrap: 'wrap' }}>
+            <div className="row gap-12 mt-8">
               {metrics.map(k => (
-                <label key={`m_${k}`} className="row" style={{ gap: 6 }}>
+                <label key={`m_${k}`} className="row gap-6">
                   <input type="checkbox" checked={visibleMetrics.includes(k)} onChange={()=>toggleMetric(k)} />
                   <span>{metricLabels[k] || k}</span>
                 </label>
@@ -258,8 +258,8 @@ export default function Dashboard() {
         </div>
 
         {/* Team table */}
-        <div style={{ overflowX: 'auto' }}>
-          <table className="table" style={{ minWidth: 720 }}>
+        <div className="overflow-x-auto">
+          <table className="table min-w-720">
             <thead>
               <tr>
                 <th className="clickable" onClick={()=>onSort('team_number')}>Team {sortKey==='team_number' ? (sortDir==='asc'?'▲':'▼') : ''}</th>
@@ -273,7 +273,7 @@ export default function Dashboard() {
             <tbody>
               {sortedTeams.map(t => (
                 <tr key={t.team_number}>
-                  <td><button className="btn" onClick={()=>setTeamOpen(t.team_number)} style={{ padding: '4px 8px' }}>{t.team_number}</button></td>
+                  <td><button className="btn small" onClick={()=>setTeamOpen(t.team_number)}>{t.team_number}</button></td>
                   <td><span className="clickable" onClick={()=>setTeamOpen(t.team_number)}>{t.nickname || ''}</span></td>
                   <td>{t.played}</td>
                   {visibleMetrics.map(k => {
@@ -360,13 +360,13 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
         <div className="header">
-          <h3 style={{ margin: 0 }}>Team {teamNumber} {detail?.meta?.nickname ? `— ${detail.meta.nickname}` : ''}</h3>
+          <h3 className="no-margin">Team {teamNumber} {detail?.meta?.nickname ? `— ${detail.meta.nickname}` : ''}</h3>
           <button className="close" onClick={onClose}>Close</button>
         </div>
         {loading && <p className="help">Loading…</p>}
         {error && <div className="error" role="alert">Error: {error}</div>}
-        {!loading && !error && (
-          <div className="grid two" style={{ marginTop: 12 }}>
+          {!loading && !error && (
+          <div className="grid two mt-12">
             <div>
               <h4>Pit</h4>
               <p className="help">Drivetrain: {pit?.drivetrain || '-'} · Weight: {pit?.weight_lb ?? '-'} lb</p>
@@ -374,7 +374,7 @@ function TeamModal({ teamNumber, onClose }: { teamNumber: number, onClose: () =>
               {mechs && (typeof mechs === 'object') && ('text' in mechs) && <p className="help">Mechanisms: {mechs.text}</p>}
               {pit?.notes && <p className="help">Notes: {pit.notes}</p>}
               {photos.length > 0 && (
-                <div className="row" style={{ marginTop: 8 }}>
+                <div className="row mt-8">
                   {photos.map((u,i)=>(<img key={i} src={u} alt="pit" className="thumb" onClick={()=>setPhotoOpen(u)} />))}
                 </div>
               )}

--- a/scout/src/pages/MatchForm.tsx
+++ b/scout/src/pages/MatchForm.tsx
@@ -214,7 +214,7 @@ export default function MatchForm() {
               const val = !!metrics[key]
               return (
                 <div className="row" key={key}>
-                  <label className="muted" style={{ minWidth: 160 }}>{f.label}</label>
+                  <label className="muted min-w-160">{f.label}</label>
                   <div className="qty">
                     <button className={`btn ${val ? 'primary' : ''}`} onClick={() => updateMetric(key, true)}>Yes</button>
                     <button className={`btn ${!val ? 'primary' : ''}`} onClick={() => updateMetric(key, false)}>No</button>
@@ -251,7 +251,7 @@ export default function MatchForm() {
         <h4>Discipline &amp; Status</h4>
         <CounterRow label="Penalties" value={penalties} onChange={(n)=>setPenalties(Number.isFinite(n) ? n : 0)} />
         <div className="row">
-          <label className="muted" style={{ minWidth: 160 }}>Broke Down</label>
+          <label className="muted min-w-160">Broke Down</label>
           <div className="qty">
             <button className={`btn ${brokeDown ? 'primary' : ''}`} onClick={() => setBrokeDown(true)}>Yes</button>
             <button className={`btn ${!brokeDown ? 'primary' : ''}`} onClick={() => setBrokeDown(false)}>No</button>

--- a/scout/src/pages/PitForm.tsx
+++ b/scout/src/pages/PitForm.tsx
@@ -69,7 +69,7 @@ export default function PitForm() {
 
   return (
     <div className="container">
-      <div className="row" style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+      <div className="row between">
         <h2>{game.name} - Pit Scouting</h2>
         <a className="btn" href={exportHref}>Export CSV</a>
       </div>
@@ -115,9 +115,9 @@ export default function PitForm() {
           <div className="field">
             <label>Dimensions (H-W-L in)</label>
             <div className="row nowrap">
-              <input inputMode="numeric" placeholder="H" value={dims.h || ''} onChange={e => setDims({ ...dims, h: Number(e.target.value || 0) })} style={{ maxWidth: 80 }} />
-              <input inputMode="numeric" placeholder="W" value={dims.w || ''} onChange={e => setDims({ ...dims, w: Number(e.target.value || 0) })} style={{ maxWidth: 80 }} />
-              <input inputMode="numeric" placeholder="L" value={dims.l || ''} onChange={e => setDims({ ...dims, l: Number(e.target.value || 0) })} style={{ maxWidth: 80 }} />
+              <input className="max-w-80" inputMode="numeric" placeholder="H" value={dims.h || ''} onChange={e => setDims({ ...dims, h: Number(e.target.value || 0) })} />
+              <input className="max-w-80" inputMode="numeric" placeholder="W" value={dims.w || ''} onChange={e => setDims({ ...dims, w: Number(e.target.value || 0) })} />
+              <input className="max-w-80" inputMode="numeric" placeholder="L" value={dims.l || ''} onChange={e => setDims({ ...dims, l: Number(e.target.value || 0) })} />
             </div>
           </div>
         </div>
@@ -155,9 +155,9 @@ export default function PitForm() {
         </div>
 
         {photoBlobs.length > 0 && (
-          <div className="row" style={{ flexWrap: 'wrap', gap: 10 }}>
+          <div className="row">
             {photoBlobs.map((p, i) => (
-              <div key={i} className="row" style={{ gap: 8 }}>
+              <div key={i} className="row gap-8">
                 <Thumb blob={p.blob} alt={`photo ${i+1}`} />
                 <button className="btn" onClick={() => removePhoto(i)}>Remove</button>
               </div>

--- a/scout/src/pages/Sync.tsx
+++ b/scout/src/pages/Sync.tsx
@@ -93,7 +93,7 @@ export default function SyncPage() {
 
       <div className="card">
         <h4>Log</h4>
-        <div className="muted" style={{ whiteSpace: 'pre-wrap' }}>
+        <div className="muted pre-wrap">
           {log.length ? log.join('\n') : '—'}
         </div>
       </div>

--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -213,13 +213,29 @@ h1, h2, h3, h4, h5, h6,
 /* Rows */
 .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
+/* Layout utilities */
+.between { justify-content: space-between; }
+.justify-end { justify-content: flex-end; }
+.gap-6 { gap: 6px; }
+.gap-8 { gap: 8px; }
+.gap-12 { gap: 12px; }
+.mt-8 { margin-top: 8px; }
+.mt-12 { margin-top: 12px; }
+.ml-8 { margin-left: 8px; }
+.no-margin { margin: 0; }
+.min-w-160 { min-width: 160px; }
+.min-w-720 { min-width: 720px; }
+.max-w-80 { max-width: 80px; }
+.overflow-x-auto { overflow-x: auto; }
+.pre-wrap { white-space: pre-wrap; }
+
 /* Utility: keep content on a single line, used for – [input] + on Match */
 .nowrap { flex-wrap: nowrap !important; }
 
 /* Buttons */
 button, input, select, textarea { color: inherit; font: inherit; }
 
-.btn {
+.btn { 
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -235,6 +251,8 @@ button, input, select, textarea { color: inherit; font: inherit; }
 .btn:hover { background: #0d1324; border-color: var(--border-strong); }
 .btn:active { transform: translateY(1px); }
 .btn:disabled { opacity: .5; pointer-events: none; }
+
+.btn.small { padding: 4px 8px; }
 
 .btn.primary {
   background: var(--accent);
@@ -277,6 +295,12 @@ button, input, select, textarea { color: inherit; font: inherit; }
 
 /* Station row (legacy) — keep mobile behavior tidy */
 .row.station { gap: 8px; }
+
+/* Tables */
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { padding: 8px; text-align: left; }
+.table tbody tr:nth-child(odd) { background: rgba(255,255,255,0.03); }
+.table tbody tr:nth-child(even) { background: rgba(255,255,255,0.06); }
 
 /* Images (thumbnails in Pit) */
 .thumb {


### PR DESCRIPTION
## Summary
- add alternating theme-friendly colors for dashboard table rows
- move inline component styles into reusable classes in `styles.css`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4d6e438cc832b8d8d5a7bdadb1cf4