### PR TITLE
feat: show unsynced count badge on sync button

### DIFF
--- a/scout/src/App.css
+++ b/scout/src/App.css
@@ -1,0 +1,20 @@
+.sync-text {
+  position: relative;
+  display: inline-block;
+}
+
+.sync-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #062a3a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- show unsynced-record count as a badge over the Sync button
- style badge to be circular and positioned at the button's top-right
- truncate counts above 9 to `9+`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4e4bd01c4832b8ea023f8a19c9145