### PR TITLE
Update sync badge after form saves

### DIFF
--- a/scout/src/pages/MatchForm.tsx
+++ b/scout/src/pages/MatchForm.tsx
@@ -322,8 +322,12 @@ export default function MatchForm() {
             // reset UI
             setMetrics(initialMetrics)
             setPenalties(0); setBrokeDown(false); setDefensePlayed(0); setDefenseResilience(0); setDriverSkill(3); setCard('none')
-
             alert(teamNumber ? `Saved for Team ${labelForTeam(teamNumber, teamMeta)}` : 'Saved locally')
+            window.dispatchEvent(
+              new CustomEvent('scout:cache-updated', {
+                detail: { kind: 'match-save', eventKey: settings.eventKey }
+              })
+            )
             const nextMatch = localMatch + 1
             setLocalMatch(nextMatch)
             setSettings((prev: Settings) => ({ ...prev, matchNumber: nextMatch }))

--- a/scout/src/pages/PitForm.tsx
+++ b/scout/src/pages/PitForm.tsx
@@ -217,6 +217,11 @@ export default function PitForm() {
             setNotes('')
             setPhotoBlobs([])
             alert(`Saved for Team ${labelForTeam(rec.teamNumber)}`)
+            window.dispatchEvent(
+              new CustomEvent('scout:cache-updated', {
+                detail: { kind: 'pit-save', eventKey: settings.eventKey }
+              })
+            )
           }}
         >
           Save


### PR DESCRIPTION
## Summary
- Dispatch cache-updated event after saving pit form to refresh sync badge
- Dispatch cache-updated event after saving match form to refresh sync badge

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e6a23a38832ba10d9d90c6af87df