### PR TITLE
Expand layout width for desktop dashboards

### DIFF
--- a/scout/src/styles.css
+++ b/scout/src/styles.css
@@ -35,7 +35,7 @@ h1, h2, h3, h4, h5, h6,
 
 /* Layout */
 .container {
-  max-width: 1000px;
+  max-width: 1600px;
   margin: 0 auto;
   padding: 16px;
   overflow-x: hidden;
@@ -46,7 +46,7 @@ h1, h2, h3, h4, h5, h6,
 .footer {
   background: rgba(255,255,255,0.05);
   backdrop-filter: blur(8px);
-  max-width: 1000px;
+  max-width: 1600px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- Increase `.container`, `.nav`, and `.footer` `max-width` from `1000px` to `1600px`
- Keep navigation and footer centered with `margin: 0 auto`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e82fee98832b883ecaf34b3a9f52